### PR TITLE
1kplus

### DIFF
--- a/includes/replace.form.inc
+++ b/includes/replace.form.inc
@@ -84,7 +84,7 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
     '#empty' => l(t('No matching objects were found. Search again.'),
       'admin/islandora/tools/find-replace/find'),
     '#js_select' => TRUE,
-    '#attributes' => array('id' => 'selectall'),
+    '#attributes' => array('class' => array('form-checkbox','in_tableselect')),
   );
   $max_input_vars = array(
    "maxInputVars" =>  ini_get("max_input_vars"),

--- a/includes/replace.form.inc
+++ b/includes/replace.form.inc
@@ -79,13 +79,11 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
     '#options' => $options,
     '#empty' => l(t('No matching objects were found. Search again.'),
       'admin/islandora/tools/find-replace/find'),
-    '#js_select' => TRUE,
     '#attributes' => array('class' => array('form-checkbox', 'in_tableselect')),
   );
   $max_input_vars = array(
-   "maxInputVars" =>  ini_get("max_input_vars"),
+   "maxInputVars" =>  $php_max_input_vars,
  );
- $islandora_path = drupal_get_path('module', 'islandora');
  $path = drupal_get_path('module', 'islandora_find_replace') . '/js/islandora_find_replace.js';
  drupal_add_js(array("islandora_find_replace" => $max_input_vars), "setting");
  $form['#attached']['js'][] = array(

--- a/includes/replace.form.inc
+++ b/includes/replace.form.inc
@@ -67,15 +67,6 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
     '#type' => 'markup',
     '#markup' => "<p>" . "If your set of items is larger than " . $php_max_input_vars . " you can use the 'Process All' button. Alternatively you should refine your search or only apply less than " . $php_max_input_vars . " items per batch</p>"
   );
-  $form['preview'] = array(
-    '#type' => 'tableselect',
-    '#header' => $header,
-    '#options' => $options,
-    '#empty' => l(t('No matching objects were found. Search again.'),
-      'admin/islandora/tools/find-replace/find'),
-    '#js_select' => TRUE,
-    '#attributes' => array('id' => 'selectall'),
-  );
   $form['process_all'] =  array(
     '#type' => 'checkbox',
     '#title' => t('Check here to process all found results(cannot be undone!)'),
@@ -86,6 +77,15 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
       '#value' => t('Replace String'),
     );
   }
+  $form['preview'] = array(
+    '#type' => 'tableselect',
+    '#header' => $header,
+    '#options' => $options,
+    '#empty' => l(t('No matching objects were found. Search again.'),
+      'admin/islandora/tools/find-replace/find'),
+    '#js_select' => TRUE,
+    '#attributes' => array('id' => 'selectall'),
+  );
   $max_input_vars = array(
    "maxInputVars" =>  ini_get("max_input_vars"),
  );

--- a/includes/replace.form.inc
+++ b/includes/replace.form.inc
@@ -65,6 +65,10 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
     '#empty' => l(t('No matching objects were found. Search again.'),
       'admin/islandora/tools/find-replace/find'),
   );
+  $form['process_all'] =  array(
+    '#type' => 'checkbox',
+    '#title' => t('Check here to process all found results(cannot be undone!)'),
+  );
 
   if (count($options)) {
     $form['submit'] = array(
@@ -85,7 +89,7 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
  *   The form state array.
  */
 function islandora_find_replace_replace_form_submit($form, &$form_state) {
-  $selected = array_keys(array_filter($form_state['values']['preview']));
+  $selected = $form_state['values']['process_all'] ? array_keys($form_state['values']['preview']) : array_keys(array_filter($form_state['values']['preview']));
 
   $operations = array();
   foreach ($selected as $select) {

--- a/includes/replace.form.inc
+++ b/includes/replace.form.inc
@@ -60,13 +60,9 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
   );
   $form['total'] = array(
   '#type' => 'markup',
-  '#markup' =>  "<p>". "Total number of items that match search: " . t(count(unserialize($find_replace['find_results']))) . "</p>",
+  '#markup' =>  "<p>Total number of items that match search: " . t(count(unserialize($find_replace['find_results']))) . "</p>",
 );
   $php_max_input_vars = ini_get('max_input_vars');
-  $form['warning'] = array(
-    '#type' => 'markup',
-    '#markup' => "<p></p>"
-  );
   $form['process_all'] =  array(
     '#type' => 'checkbox',
     '#title' => t("If set of selected results is larger than the limit of $php_max_input_vars items, you may process all items by checking this box."),

--- a/includes/replace.form.inc
+++ b/includes/replace.form.inc
@@ -64,6 +64,7 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
     '#options' => $options,
     '#empty' => l(t('No matching objects were found. Search again.'),
       'admin/islandora/tools/find-replace/find'),
+    '#js_select' => FALSE,
   );
   $form['process_all'] =  array(
     '#type' => 'checkbox',

--- a/includes/replace.form.inc
+++ b/includes/replace.form.inc
@@ -58,12 +58,13 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
     '#type' => 'markup',
     '#markup' => l(t('Back (New Search)'), 'admin/islandora/tools/find-replace/find'),
   );
+  $count = (string) count(unserialize($find_replace['find_results']));
   $form['total'] = array(
-  '#type' => 'markup',
-  '#markup' =>  "<p>Total number of items that match search: " . t(count(unserialize($find_replace['find_results']))) . "</p>",
-);
+    '#type' => 'markup',
+    '#markup' => "<p>Total number of items that match search: $count</p>",
+  );
   $php_max_input_vars = ini_get('max_input_vars');
-  $form['process_all'] =  array(
+  $form['process_all'] = array(
     '#type' => 'checkbox',
     '#title' => t("If selecting all checkboxes in the table below results in a warning, use this checkbox as an alternate means to 'select all'."),
   );
@@ -82,16 +83,15 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
     '#attributes' => array('class' => array('form-checkbox', 'in_tableselect')),
   );
   $max_input_vars = array(
-   "maxInputVars" =>  $php_max_input_vars,
- );
- $path = drupal_get_path('module', 'islandora_find_replace') . '/js/islandora_find_replace.js';
- drupal_add_js(array("islandora_find_replace" => $max_input_vars), "setting");
- $form['#attached']['js'][] = array(
-     'data' => $path,
-     'type' => 'file',
-     'scope' => 'footer',
- );
-
+    "maxInputVars" => $php_max_input_vars,
+  );
+  $path = drupal_get_path('module', 'islandora_find_replace') . '/js/islandora_find_replace.js';
+  drupal_add_js(array("islandora_find_replace" => $max_input_vars), "setting");
+  $form['#attached']['js'][] = array(
+    'data' => $path,
+    'type' => 'file',
+    'scope' => 'footer',
+  );
   return $form;
 }
 
@@ -108,12 +108,14 @@ function islandora_find_replace_replace_form_submit($form, &$form_state) {
 
   $operations = array();
   foreach ($selected as $select) {
-    $operations[] = array('islandora_find_replace_update_objects', array(
-      $select,
-      $form_state['storage']['find_replace']['dsid'],
-      $form_state['storage']['find_replace']['find'],
-      $form_state['storage']['find_replace']['replacement'],
-      $form_state['storage']['find_replace']['id']),
+    $operations[] = array('islandora_find_replace_update_objects',
+      array(
+        $select,
+        $form_state['storage']['find_replace']['dsid'],
+        $form_state['storage']['find_replace']['find'],
+        $form_state['storage']['find_replace']['replacement'],
+        $form_state['storage']['find_replace']['id'],
+      ),
     );
   }
   $batch = array(

--- a/includes/replace.form.inc
+++ b/includes/replace.form.inc
@@ -65,11 +65,11 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
   $php_max_input_vars = ini_get('max_input_vars');
   $form['warning'] = array(
     '#type' => 'markup',
-    '#markup' => "<p>" . "If your set of items is larger than " . $php_max_input_vars . " you can use the 'Process All' button. Alternatively you should refine your search or only apply less than " . $php_max_input_vars . " items per batch</p>"
+    '#markup' => "<p></p>"
   );
   $form['process_all'] =  array(
     '#type' => 'checkbox',
-    '#title' => t('Check here to process all found results(cannot be undone!)'),
+    '#title' => t("If set of selected results is larger than the limit of $php_max_input_vars items, you may process all items by checking this box."),
   );
   if (count($options)) {
     $form['submit'] = array(

--- a/includes/replace.form.inc
+++ b/includes/replace.form.inc
@@ -58,25 +58,45 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
     '#type' => 'markup',
     '#markup' => l(t('Back (New Search)'), 'admin/islandora/tools/find-replace/find'),
   );
+  $form['total'] = array(
+  '#type' => 'markup',
+  '#markup' =>  "<p>". "Total number of items that match search: " . t(count(unserialize($find_replace['find_results']))) . "</p>",
+);
+  $php_max_input_vars = ini_get('max_input_vars');
+  $form['warning'] = array(
+    '#type' => 'markup',
+    '#markup' => "<p>" . "If your set of items is larger than " . $php_max_input_vars . " you can use the 'Process All' button. Alternatively you should refine your search or only apply less than " . $php_max_input_vars . " items per batch</p>"
+  );
   $form['preview'] = array(
     '#type' => 'tableselect',
     '#header' => $header,
     '#options' => $options,
     '#empty' => l(t('No matching objects were found. Search again.'),
       'admin/islandora/tools/find-replace/find'),
-    '#js_select' => FALSE,
+    '#js_select' => TRUE,
+    '#attributes' => array('id' => 'selectall'),
   );
   $form['process_all'] =  array(
     '#type' => 'checkbox',
     '#title' => t('Check here to process all found results(cannot be undone!)'),
   );
-
   if (count($options)) {
     $form['submit'] = array(
       '#type' => 'submit',
       '#value' => t('Replace String'),
     );
   }
+  $max_input_vars = array(
+   "maxInputVars" =>  ini_get("max_input_vars"),
+ );
+ $islandora_path = drupal_get_path('module', 'islandora');
+ $path = drupal_get_path('module', 'islandora_find_replace') . '/js/islandora_find_replace.js';
+ drupal_add_js(array("islandora_find_replace" => $max_input_vars), "setting");
+ $form['#attached']['js'][] = array(
+     'data' => $path,
+     'type' => 'file',
+     'scope' => 'footer',
+ );
 
   return $form;
 }

--- a/includes/replace.form.inc
+++ b/includes/replace.form.inc
@@ -65,7 +65,7 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
   $php_max_input_vars = ini_get('max_input_vars');
   $form['process_all'] =  array(
     '#type' => 'checkbox',
-    '#title' => t("If set of selected results is larger than the limit of $php_max_input_vars items, you may process all items by checking this box."),
+    '#title' => t("If selecting all checkboxes in the table below results in a warning, use this checkbox as an alternate means to 'select all'."),
   );
   if (count($options)) {
     $form['submit'] = array(
@@ -80,7 +80,7 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
     '#empty' => l(t('No matching objects were found. Search again.'),
       'admin/islandora/tools/find-replace/find'),
     '#js_select' => TRUE,
-    '#attributes' => array('class' => array('form-checkbox','in_tableselect')),
+    '#attributes' => array('class' => array('form-checkbox', 'in_tableselect')),
   );
   $max_input_vars = array(
    "maxInputVars" =>  ini_get("max_input_vars"),

--- a/js/islandora_find_replace.js
+++ b/js/islandora_find_replace.js
@@ -4,7 +4,7 @@
  */
 
 const maxInputVars = Drupal.settings.islandora_find_replace.maxInputVars;
-const message = `You have selected more than the php variable max_input_vars will allow. Don't select over ${maxInputVars} items in the form!`;
+const message = `You have selected more checkboxes than this system can handle (max_input_vars: ${maxInputVars}).`;
 const markup = `<div id="console" class="clearfix"><div id="find_replace_warning" class="messages error"><h2 class="element-invisible">Status message</h2><pre>${message}</pre></div></div>`;
 
 (function ($) {

--- a/js/islandora_find_replace.js
+++ b/js/islandora_find_replace.js
@@ -3,22 +3,23 @@
  * check if max_input_vars is met on form.
  */
 
-maxInputVars = Drupal.settings.islandora_find_replace.maxInputVars;
-message = `You have selected more than the php variable max_input_vars will allow. Don't select over ${maxInputVars} items in the form!`;
-markup = `<div id="console" class="clearfix"><div id="find_replace_warning" class="messages error"><h2 class="element-invisible">Status message</h2><pre>${message}</pre></div></div>`;
+const maxInputVars = Drupal.settings.islandora_find_replace.maxInputVars;
+const message = `You have selected more than the php variable max_input_vars will allow. Don't select over ${maxInputVars} items in the form!`;
+const markup = `<div id="console" class="clearfix"><div id="find_replace_warning" class="messages error"><h2 class="element-invisible">Status message</h2><pre>${message}</pre></div></div>`;
 
 (function ($) {
   Drupal.behaviors.tooManyMessage = {
     attach: function (context, settings) {
-      $.fn.tooManySelected = function() {
-        selected = this.parent().parent().parent('.selected').length;
-        messageExists = $('#find_replace_warning').length;
+
+      $.fn.tooManySelected = function () {
+        const selected = this.parent().parent().parent('.selected').length;
+        const messageExists = $('#find_replace_warning').length;
 
         if (selected < maxInputVars){
           if (messageExists) {
-            $('#find_replace_warning').parent().html('');
-            $("form").submit(function(){
-              $(this).unbind('submit').submit()
+            $('#find_replace_warning').remove();
+            $("form").submit(function () {
+              $(this).unbind('submit').submit();
             });
           }
         }
@@ -26,14 +27,16 @@ markup = `<div id="console" class="clearfix"><div id="find_replace_warning" clas
         else {
           if(!messageExists){
             $('#content.clearfix').prepend(markup);
-            $("form").submit(function(e){
+            $("form").submit(function (e) {
               e.preventDefault();
             });
           }
         }
       }
-      $('#edit-process-all').change(function(){
-        if(this.checked === true) {
+
+      $('#edit-process-all').change(function () {
+        if (this.checked === true) {
+          $('#find_replace_warning').remove();
           $('.form-checkbox.in_tableselect').attr('checked', false);
           $('#selectall.form-checkbox').attr('checked', false);
           $('.select-all').children().attr('checked', false);
@@ -41,12 +44,12 @@ markup = `<div id="console" class="clearfix"><div id="find_replace_warning" clas
         }
       });
 
-      $('.select-all').change(function(){
+      $('.select-all').change(function () {
         $('#edit-process-all').attr('checked', false);
         $('.form-checkbox').tooManySelected();
       });
 
-      $('.form-checkbox.in_tableselect').change(function(){
+      $('.form-checkbox.in_tableselect').change(function () {
         if (this.click) {
           $('.form-checkbox').tooManySelected();
         }

--- a/js/islandora_find_replace.js
+++ b/js/islandora_find_replace.js
@@ -25,7 +25,7 @@ const markup = `<div id="console" class="clearfix"><div id="find_replace_warning
         }
 
         else {
-          if(!messageExists){
+          if (!messageExists) {
             $('#content.clearfix').prepend(markup);
             $("form").submit(function (e) {
               e.preventDefault();

--- a/js/islandora_find_replace.js
+++ b/js/islandora_find_replace.js
@@ -33,7 +33,6 @@ markup = `<div id="console" class="clearfix"><div id="find_replace_warning" clas
         }
       }
       $('#edit-process-all').change(function(){
-        console.log(this.checked);
         if(this.checked === true){
           $('#selectall.form-checkbox').attr('checked', false);
           $('.select-all').children().attr('checked', false);
@@ -42,6 +41,7 @@ markup = `<div id="console" class="clearfix"><div id="find_replace_warning" clas
       });
 
       $('.select-all').change(function(){
+        $('#edit-process-all').attr('checked', false);
         $('.form-checkbox').tooManySelected();
       });
 
@@ -54,4 +54,3 @@ markup = `<div id="console" class="clearfix"><div id="find_replace_warning" clas
     }
   }
 }(jQuery));
-

--- a/js/islandora_find_replace.js
+++ b/js/islandora_find_replace.js
@@ -33,7 +33,8 @@ markup = `<div id="console" class="clearfix"><div id="find_replace_warning" clas
         }
       }
       $('#edit-process-all').change(function(){
-        if(this.checked === true){
+        if(this.checked === true) {
+          $('.form-checkbox.in_tableselect').attr('checked', false);
           $('#selectall.form-checkbox').attr('checked', false);
           $('.select-all').children().attr('checked', false);
           $('tbody').children().removeClass('selected');
@@ -45,9 +46,12 @@ markup = `<div id="console" class="clearfix"><div id="find_replace_warning" clas
         $('.form-checkbox').tooManySelected();
       });
 
-      $('.form-checkbox').change(function(){
-        if(this.click) {
+      $('.form-checkbox.in_tableselect').change(function(){
+        if (this.click) {
           $('.form-checkbox').tooManySelected();
+        }
+        if (this.checked === true) {
+          $('#edit-process-all').attr('checked', false);
         }
       });
 

--- a/js/islandora_find_replace.js
+++ b/js/islandora_find_replace.js
@@ -1,0 +1,57 @@
+/**
+ * @file
+ * check if max_input_vars is met on form.
+ */
+
+maxInputVars = Drupal.settings.islandora_find_replace.maxInputVars;
+message = `You have selected more than the php variable max_input_vars will allow. Don't select over ${maxInputVars} items in the form!`;
+markup = `<div id="console" class="clearfix"><div id="find_replace_warning" class="messages error"><h2 class="element-invisible">Status message</h2><pre>${message}</pre></div></div>`;
+
+(function ($) {
+  Drupal.behaviors.tooManyMessage = {
+    attach: function (context, settings) {
+      $.fn.tooManySelected = function() {
+        selected = this.parent().parent().parent('.selected').length;
+        messageExists = $('#find_replace_warning').length;
+
+        if (selected < maxInputVars){
+          if (messageExists) {
+            $('#find_replace_warning').parent().html('');
+            $("form").submit(function(){
+              $(this).unbind('submit').submit()
+            });
+          }
+        }
+
+        else {
+          if(!messageExists){
+            $('#content.clearfix').prepend(markup);
+            $("form").submit(function(e){
+              e.preventDefault();
+            });
+          }
+        }
+      }
+      $('#edit-process-all').change(function(){
+        console.log(this.checked);
+        if(this.checked === true){
+          $('#selectall.form-checkbox').attr('checked', false);
+          $('.select-all').children().attr('checked', false);
+          $('tbody').children().removeClass('selected');
+        }
+      });
+
+      $('.select-all').change(function(){
+        $('.form-checkbox').tooManySelected();
+      });
+
+      $('.form-checkbox').change(function(){
+        if(this.click) {
+          $('.form-checkbox').tooManySelected();
+        }
+      });
+
+    }
+  }
+}(jQuery));
+


### PR DESCRIPTION
The table-select in the replace.form made it possible for users to submit a number of form elements, which could easily exceed that allowed by the PHP setting 'max_input_vars'. In this circumstance the replace form reloads and does not proceed to the batch process.

 We have added jquery in js/islandora_find_replace.js to check if the form has exceeded the 'max_input_vars' limit before submitting and to provide a warning message. We also moved the submit button to the top of the form, and have added a separate checkbox that will allow the submission of all items in the form  to the batch process.